### PR TITLE
Добавление проверки что участник чата заблокирован после того как бот показал капчу.

### DIFF
--- a/handlers/group/main_logic.py
+++ b/handlers/group/main_logic.py
@@ -78,7 +78,7 @@ async def new_chat_member(message: types.Message):
         if data.get('user_id', None):
             logger.debug(f'User @{new_member.username}:{new_member.id} data: {data}')
             until_date = datetime.datetime.now() + datetime.timedelta(seconds=BAN_TIME)
-            # Получаем информацию о пользователе и проверям не заблокировал ли его кто-то пока бот ожидал ответа на капчу. asyncio так как требуются свежие данные, а не на время входа в цикл.
+            # Получаем информацию о пользователе и провереям не заблокировал ли его кто-то пока бот ожидал ответа на капчу. asyncio так как требуются свежие данные, а не на время входа в цикл.
             asyncio.user = await bot.get_chat_member(chat_id=message.chat.id, user_id=new_member.id)
             if asyncio.user['status'] == 'kicked':
             # Если пользователь заблокирован в чате то ничего не делаем и просто выдаём сообщение в консоль

--- a/handlers/group/main_logic.py
+++ b/handlers/group/main_logic.py
@@ -78,11 +78,14 @@ async def new_chat_member(message: types.Message):
         if data.get('user_id', None):
             logger.debug(f'User @{new_member.username}:{new_member.id} data: {data}')
             until_date = datetime.datetime.now() + datetime.timedelta(seconds=BAN_TIME)
-            # Получаем информацию о пользователе и провереям не заблокировал ли его кто-то пока бот ожидал ответа на капчу. asyncio так как требуются свежие данные, а не на время входа в цикл.
+            # Получаем информацию о пользователе и провереям не заблокировал ли его кто-то, 
+            # пока бот ожидал ответа на капчу.
+            # asyncio так как требуются свежие данные, а не на время входа в цикл.
             asyncio.user = await bot.get_chat_member(chat_id=message.chat.id, user_id=new_member.id)
             if asyncio.user['status'] == 'kicked':
             # Если пользователь заблокирован в чате то ничего не делаем и просто выдаём сообщение в консоль
-                logger.debug(f'User @{new_member.username}:{new_member.id} already kicked from the chat ("{message.chat.title}@{message.chat.username}" chat_id:{message.chat.id}) by other bot or admin')
+                logger.debug(f'User @{new_member.username}:{new_member.id} already kicked from the chat \
+                ("{message.chat.title}@{message.chat.username}" chat_id:{message.chat.id}) by other bot or admin')
             else:
             # Если пользователь не был заблокирован то назначается его блокировка на указанное в конфигурации время
                 await bot.kick_chat_member(chat_id=message.chat.id, user_id=new_member.id, until_date=until_date)

--- a/handlers/group/main_logic.py
+++ b/handlers/group/main_logic.py
@@ -78,8 +78,15 @@ async def new_chat_member(message: types.Message):
         if data.get('user_id', None):
             logger.debug(f'User @{new_member.username}:{new_member.id} data: {data}')
             until_date = datetime.datetime.now() + datetime.timedelta(seconds=BAN_TIME)
-            await bot.kick_chat_member(chat_id=message.chat.id, user_id=new_member.id, until_date=until_date)
-            logger.debug(f'User was kicked from chat @{new_member.username}:{new_member.id} on {BAN_TIME} seconds')
+            asyncio.user = await bot.get_chat_member(chat_id=message.chat.id, user_id=new_member.id)
+            if asyncio.user['status'] == 'kicked':
+                logger.debug(f'User @{new_member.username}:{new_member.id} already kicked from the chat ("{message.chat.title}@{message.chat.username}" chat_id:{message.chat.id}) by other bot or admin')
+            else:
+                await bot.kick_chat_member(chat_id=message.chat.id, user_id=new_member.id, until_date=until_date)
+                logger.debug(f'User was kicked from chat @{new_member.username}:{new_member.id} on {BAN_TIME} seconds')
+            state = dp.current_state(user=new_member.id, chat=message.chat.id)
+            await state.finish()
+            logger.debug(f'User @{new_member.username}:{new_member.id} is out of the state')
 
     for service_message in service_messages:
         logger.debug(f'Message {service_message.message_id} was deleted')

--- a/handlers/group/main_logic.py
+++ b/handlers/group/main_logic.py
@@ -78,12 +78,16 @@ async def new_chat_member(message: types.Message):
         if data.get('user_id', None):
             logger.debug(f'User @{new_member.username}:{new_member.id} data: {data}')
             until_date = datetime.datetime.now() + datetime.timedelta(seconds=BAN_TIME)
+            # Получаем информацию о пользователе и проверям не заблокировал ли его кто-то пока бот ожидал ответа на капчу. asyncio так как требуются свежие данные, а не на время входа в цикл.
             asyncio.user = await bot.get_chat_member(chat_id=message.chat.id, user_id=new_member.id)
             if asyncio.user['status'] == 'kicked':
+            # Если пользователь заблокирован в чате то ничего не делаем и просто выдаём сообщение в консоль
                 logger.debug(f'User @{new_member.username}:{new_member.id} already kicked from the chat ("{message.chat.title}@{message.chat.username}" chat_id:{message.chat.id}) by other bot or admin')
             else:
+            # Если пользователь не был заблокирован то назначается его блокировка на указанное в конфигурации время
                 await bot.kick_chat_member(chat_id=message.chat.id, user_id=new_member.id, until_date=until_date)
                 logger.debug(f'User was kicked from chat @{new_member.username}:{new_member.id} on {BAN_TIME} seconds')
+            # Завершаем состояние "новый пользователь", если пользователь просто проигнорировал капчу
             state = dp.current_state(user=new_member.id, chat=message.chat.id)
             await state.finish()
             logger.debug(f'User @{new_member.username}:{new_member.id} is out of the state')


### PR DESCRIPTION
Далее более расширенные комментарии чем в коде, которые поясняют что и почему.

Получаем информацию о пользователе и проверяем не заблокировал ли его кто-то пока бот ожидал ответа на капчу.
Если пользователь заблокирован в чате то ничего не делаем и просто выдаём сообщение в консоль, иначе это позволяет обойти блокировку, так как капчабот переназначает время блокировки.
Если пользователь не был заблокирован то назначается его блокировка.
Завершаем состояние "новый пользователь", если пользователь просто проигнорировал капчу, иначе по истечении временной блокировки пользователь при повторном входе не получал капчу и таким образом мог её обойти.